### PR TITLE
리팩토링

### DIFF
--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -47,16 +47,15 @@ instance.interceptors.response.use(
     }
 
     if (isUnAuthError) {
-      if (data?.code === 'TOKEN_INVALID') {
-        alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
-        window.location.href = `${CONFIG.API_BASE_URL}/auth/login`;
-        return;
-      }
-
       if (data?.code === 'TOKEN_EXPIRED') {
         const { accessToken } = await refreshToken();
         setCookie('accessToken', accessToken);
         return instance.request(originalRequest);
+      }
+      if (data?.code === 'TOKEN_INVALID') {
+        window.location.href = `${CONFIG.LOCAL}/auth/login`;
+        alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
+        return;
       }
 
       return Promise.reject(error.response.data);

--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -48,13 +48,8 @@ instance.interceptors.response.use(
 
     if (isUnAuthError) {
       if (data?.code === 'TOKEN_INVALID') {
-        if (CONFIG.ENV === 'development') {
-          alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
-          window.location.href = `${CONFIG.LOCAL}/auth/login`;
-        } else if (CONFIG.ENV === 'production') {
-          alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
-          window.location.href = `${CONFIG.DOMAIN}/auth/login`;
-        }
+        alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
+        window.location.href = `${CONFIG.API_BASE_URL}/auth/login`;
         return;
       }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -145,12 +145,9 @@ export default function App({
 
 const fetchAccessToken = async (refreshToken: string) => {
   try {
-    const response = await axios.post(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/token`,
-      {
-        refreshToken,
-      },
-    );
+    const response = await axios.post(`${CONFIG.API_BASE_URL}/members/token`, {
+      refreshToken,
+    });
     return response.data.accessToken;
   } catch (error: any) {
     throw new Error(`Fetching access token failed: ${error.message}`);
@@ -160,7 +157,7 @@ const fetchAccessToken = async (refreshToken: string) => {
 const fetchUserData = async (accessToken: string) => {
   try {
     axios.defaults.headers.common['Authorization'] = accessToken;
-    axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+    axios.defaults.baseURL = CONFIG.API_BASE_URL;
     const resUserData = await axios('/members/me');
     return resUserData.data;
   } catch (error: any) {
@@ -194,7 +191,10 @@ App.getInitialProps = async ({ Component, ctx }: AppContext) => {
     const userData = await fetchUserData(accessToken);
     return { pageProps, userData };
   } catch (error) {
-    console.error(error);
+    if (!ctx.res) return;
+    ctx.res.setHeader('Location', '/auth/login');
+    ctx.res.statusCode = 302;
+    ctx.res.end();
     return { pageProps };
   }
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -143,12 +143,14 @@ export default function App({
   );
 }
 
-// Utils functions or methods inside service class
 const fetchAccessToken = async (refreshToken: string) => {
   try {
-    const response = await axios.post(`${CONFIG.API_BASE_URL}/members/token`, {
-      refreshToken,
-    });
+    const response = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/token`,
+      {
+        refreshToken,
+      },
+    );
     return response.data.accessToken;
   } catch (error: any) {
     throw new Error(`Fetching access token failed: ${error.message}`);
@@ -158,7 +160,7 @@ const fetchAccessToken = async (refreshToken: string) => {
 const fetchUserData = async (accessToken: string) => {
   try {
     axios.defaults.headers.common['Authorization'] = accessToken;
-    axios.defaults.baseURL = CONFIG.API_BASE_URL;
+    axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
     const resUserData = await axios('/members/me');
     return resUserData.data;
   } catch (error: any) {
@@ -166,7 +168,6 @@ const fetchUserData = async (accessToken: string) => {
   }
 };
 
-// The main getInitialProps function
 App.getInitialProps = async ({ Component, ctx }: AppContext) => {
   let pageProps = {};
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,6 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   };
 };
 
-export default function Home({ a }) {
+export default function Home() {
   return <></>;
 }


### PR DESCRIPTION
1. _App.tsx의 함수 모듈화
2. 토큰이 불일치할 경우, alert 후 페이지 이동을 하면 '401'화면이 잠깐 보이는 현상이 있어, 이 두 위치를 바꾸어 사용자 경험을 개선하였습니다.
3. accessToken 재발급을 실패하였을 경우에 대한 예외처리를 추가하였습니다. (auth/login 페이지로 이동)

2번과 3번으로 배포 서버에서 500에러가 발생하는 것이 해결됬기를 바랍니다.