### PR TITLE
500에러 해결

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -167,6 +167,7 @@ const fetchUserData = async (accessToken: string) => {
 
 App.getInitialProps = async ({ Component, ctx }: AppContext) => {
   let pageProps = {};
+  if (!ctx.res) return;
 
   if (Component.getInitialProps) {
     pageProps = await Component.getInitialProps(ctx);
@@ -178,7 +179,6 @@ App.getInitialProps = async ({ Component, ctx }: AppContext) => {
 
   const refreshToken = getCookie('refreshToken', ctx);
   if (!refreshToken) {
-    if (!ctx.res) return;
     ctx.res.setHeader('Location', '/auth/login');
     ctx.res.statusCode = 302;
     ctx.res.end();
@@ -191,7 +191,6 @@ App.getInitialProps = async ({ Component, ctx }: AppContext) => {
     const userData = await fetchUserData(accessToken);
     return { pageProps, userData };
   } catch (error) {
-    if (!ctx.res) return;
     ctx.res.setHeader('Location', '/auth/login');
     ctx.res.statusCode = 302;
     ctx.res.end();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
 import { getCookie, setCookie } from 'cookies-next';
 import { GetServerSideProps } from 'next';
+import { Router, useRouter } from 'next/router';
 
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const refreshToken = getCookie('refreshToken', ctx);
-  const isVisited = getCookie('isVisted', ctx);
+export default function Home() {
+  const refreshToken = getCookie('refreshToken');
+  const isVisited = getCookie('isVisted');
 
   const location = !!refreshToken
     ? '/home'
@@ -11,16 +12,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     ? '/auth/login'
     : '/begin';
 
-  if (location === '/begin') setCookie('isVisted', 'true', ctx);
-  ctx.res.setHeader('Location', location);
-  ctx.res.statusCode = 302;
-  ctx.res.end();
+  const router = useRouter();
+  router.push(location);
 
-  return {
-    props: {},
-  };
-};
-
-export default function Home() {
   return <></>;
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

_app페이지와 index페이지에서 ctx.res.end()롤 각각 수행 하여 2번의 header를 송신해 배포 서버에서 500에러가 발생했습니다. 이에 대해 해결하기 위해 index페이지에서는 Client Side에서 쿠키 여부에 따라 redirect해주었습니다.

이에 따라 500에러가 해결되기를 기대합니다.